### PR TITLE
General cleanup and improvements

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,8 +31,8 @@ pub fn build(b: *std.build.Builder) !void {
 
     exe.addBuildOption(
         bool,
-        "leak_detection",
-        b.option(bool, "leak_detection", "Use testing.LeakCountAllocator to track leaks.") orelse false,
+        "allocation_info",
+        b.option(bool, "allocation_info", "Enable use of debugging allocator and info logging.") orelse false,
     );
 
     exe.setTarget(target);


### PR DESCRIPTION
Sorry for the big PR in one commit.  
The commit message describes all changes, I will clarify a couple in this comment.  

I switched from `read` and `write` calls to `readAll` and `writeAll`.  
The filesystem streams (and any io stream in general) are not guaranteed to read or write the whole buffer.  
InStream and OutStream provide those convenience functions that repeat the calls until the whole buffer is consumed/produced or the call fails (in the case of `readAll`, it will also return if `read` returns 0).  
This is documented in `std.os`.  
Using these will save us headaches if we decide to use other streams instead (e.g. TCP) which are much more likely not to execute the whole operation in one call.  
(`print` also uses `writeAll` internally)  

Using the same JSON parser is an optimization, since the `reset` function does not free the memory allocated for its stack but instead resets its length. 

I'm very confident all memory leaks have been eliminated in this build, somehow I missed the close document method in my first PR.