### PR TITLE
Added position context detection

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -387,6 +387,8 @@ fn documentContext(doc: types.TextDocument, pos_index: usize) PositionContext {
                     string_pop_ctx = access_ctx;
                 }
                 context = .builtin;
+            } else {
+                context = .other;
             }
             continue;
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -368,7 +368,7 @@ fn documentContext(doc: types.TextDocument, pos_index: usize) PositionContext {
             continue;
         }
 
-        if (c == '.' and context != .builtin) {
+        if (c == '.' and (!new_token or context == .string_literal)) {
             new_token = true;
             context = .field_access;
             continue;

--- a/src/types.zig
+++ b/src/types.zig
@@ -142,7 +142,7 @@ pub const TextDocument = struct {
     mem: []u8,
     sane_text: ?String = null,
 
-    pub fn positionToIndex(self: *const TextDocument, position: Position) !usize {
+    pub fn positionToIndex(self: TextDocument, position: Position) !usize {
         var split_iterator = std.mem.split(self.text, "\n");
 
         var line: i64 = 0;


### PR DESCRIPTION
Added a function that takes a document and a position and returns a PositionContext.  
Currently we recognize comment, string literal, builtin, variable access and field access contexts.  

This fixes the completions showing up in comments and string literals (at least they do in vscode) and will probably be useful later.  
It could be enhanced by becoming a `union(enum)` that returns context specific data (for example, we could return a string of what we are dot accessing for the field access context to do some analysis).  

It also correctly detects `@"..."` variable/field accesses.  

Also removed a `*const Self` parameter, zig passes all arguments as const so leaving it as `Self` will cause the compiler to choose the optimal way to pass it (either const ref or by value if it is small enough).