### PR TITLE
Detect type functions and require PascalCase, require camelCase for the rest

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -87,3 +87,7 @@ pub fn getVariableSignature(tree: *std.zig.ast.Tree, var_decl: *std.zig.ast.Node
 pub fn isCamelCase(name: []const u8) bool {
     return !std.ascii.isUpper(name[0]) and std.mem.indexOf(u8, name, "_") == null;
 }
+
+pub fn isPascalCase(name: []const u8) bool {
+    return std.ascii.isUpper(name[0]) and std.mem.indexOf(u8, name, "_") == null;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -177,7 +177,7 @@ fn publishDiagnostics(document: *types.TextDocument) !void {
                     if (func.name_token) |name_token| {
                         const loc = tree.tokenLocation(0, name_token);
 
-                        var is_type_function = switch (func.return_type) {
+                        const is_type_function = switch (func.return_type) {
                             .Explicit => |node| if (node.cast(std.zig.ast.Node.Identifier)) |ident|
                                 std.mem.eql(u8, tree.tokenSlice(ident.token), "type")
                             else


### PR DESCRIPTION
Some examples of this in action:  

![image](https://user-images.githubusercontent.com/265903/81418997-358efe00-9156-11ea-9497-e0d3a4757fef.png)
_No linter warning for InStream_  

![image](https://user-images.githubusercontent.com/265903/81419056-4fc8dc00-9156-11ea-8967-5338dc78fd93.png)
_Linter warning for inStream_