### PR TITLE
Snippet improvements

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -253,6 +253,8 @@ fn completeGlobal(id: i64, document: *types.TextDocument, config: Config) !void 
                     else
                         null;
 
+                    if (insert_text != null) try log("SNIP: {}", .{insert_text});
+
                     var doc_comments = try analysis.getDocComments(&arena.allocator, tree, decl);
                     var doc = types.MarkupContent{
                         .kind = .Markdown,

--- a/src/main.zig
+++ b/src/main.zig
@@ -253,8 +253,6 @@ fn completeGlobal(id: i64, document: *types.TextDocument, config: Config) !void 
                     else
                         null;
 
-                    if (insert_text != null) try log("SNIP: {}", .{insert_text});
-
                     var doc_comments = try analysis.getDocComments(&arena.allocator, tree, decl);
                     var doc = types.MarkupContent{
                         .kind = .Markdown,


### PR DESCRIPTION
Correctly render comptime, noalias and vararg arguments.  
Only render spaces in return type tokens after commas, this allows us to generate types like `anyframe->void` better, although it probably is still not 100% ideal.  
